### PR TITLE
Update URL in get-metadata.ts

### DIFF
--- a/src/lib/get-metadata.ts
+++ b/src/lib/get-metadata.ts
@@ -32,7 +32,9 @@ export async function fetchApprovalRequestMetadata(
   };
 
   try {
-    const url = new URL(`https://dev2.worldcoin.org/api/v1/precheck/${app_id}`);
+    const url = new URL(
+      `https://developer.worldcoin.org/api/v1/precheck/${app_id}`,
+    );
     const body: ActionBody = {
       action,
       external_nullifier,


### PR DESCRIPTION
Updates URL for metadata request from `dev2.worldcoin.org` to `developer.worldcoin.org` in order to prevent long wait for metadata timeout between QR scan and verifying. fixes #127 