### PR TITLE
fix: revert sequencer password env var naming

### DIFF
--- a/src/services/sequencer.ts
+++ b/src/services/sequencer.ts
@@ -3,8 +3,8 @@ import type { InclusionProofResponse, SequencerRequest } from "@/types";
 import { CredentialType } from "@/types";
 
 const SEQUENCER_STAGING_PASSWORD: Record<CredentialType, string | undefined> = {
-  [CredentialType.Orb]: process.env.ORB_SEQUENCER_STAGING_PASSWORD,
-  [CredentialType.Phone]: process.env.PHONE_SEQUENCER_STAGING_PASSWORD,
+  [CredentialType.Orb]: process.env.POLYGON_ORB_SEQUENCER_STAGING_PASSWORD,
+  [CredentialType.Phone]: process.env.POLYGON_PHONE_SEQUENCER_STAGING_PASSWORD,
 };
 
 function buildUrl(endpoint: string, credentialType: CredentialType) {


### PR DESCRIPTION
this is a temporary fix to match existing env vars