### PR TITLE
add idkit decline verification flow

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -25,12 +25,13 @@ const getStore = (store: ModalStore) => ({
   setStatus: store.setStatus,
   metadata: store.metadata,
   request: store.request,
+  reset: store.reset,
 });
 
 export function Modal() {
-  const { open, setOpen, status, setStatus, metadata, request } =
+  const { open, setOpen, status, setStatus, metadata, reset } =
     useModalStore(getStore);
-  const { approveRequest } = useBridge();
+  const { approveRequest, declineRequest } = useBridge();
   const { activeIdentity } = useIdentity();
 
   const [showConfirm, setShowConfirm] = useState(false);
@@ -82,7 +83,11 @@ export function Modal() {
   return (
     <Drawer
       open={open}
-      onClose={() => setOpen(false)}
+      onClose={async () => {
+        setOpen(false);
+        reset();
+        await declineRequest();
+      }}
     >
       {!isLoading && !showConfirm && metadata?.is_staging && (
         <>

--- a/src/hooks/useBridge.ts
+++ b/src/hooks/useBridge.ts
@@ -133,6 +133,10 @@ export const useBridge = () => {
     [key, iv, bridgeUrl, requestId],
   );
 
+  const declineRequest = useCallback(async () => {
+    await sendResponse({ error_code: "verification_rejected" });
+  }, [sendResponse]);
+
   async function approveRequest(
     credentialTypes: CredentialType[],
   ): Promise<void> {
@@ -258,5 +262,6 @@ export const useBridge = () => {
 
   return {
     approveRequest,
+    declineRequest,
   };
 };


### PR DESCRIPTION
Since bridge requests are deleted after a single call to /request/:id, we need to inform idkit to invalidate the request UI when a user exits the verification flow.