### PR TITLE
fix: permit world-id-assets.com for images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,12 @@ const nextConfig = {
         port: "",
         pathname: "**",
       },
+      {
+        protocol: "https",
+        hostname: "world-id-assets.com",
+        port: "",
+        pathname: "**",
+      },
     ],
   },
 


### PR DESCRIPTION
allows verified app images to be loaded from `world-id-assets.com`

before:
![Screenshot 2024-02-22 at 1 40 39 PM](https://github.com/worldcoin/simulator/assets/29718876/9fc8d3d8-bc75-4821-b5b7-0be4c8a17d03)

after:
![Screenshot 2024-02-22 at 1 40 12 PM](https://github.com/worldcoin/simulator/assets/29718876/4c86c8d5-ffbc-438c-82ff-8633934b9bc8)