### PR TITLE
fix: release video stream when closing scanner

### DIFF
--- a/src/components/QR/QRScanner.tsx
+++ b/src/components/QR/QRScanner.tsx
@@ -46,7 +46,11 @@ export const QRScanner = React.memo(function QRScanner(props: QRScannerProps) {
   const { scannerOpened, setScannerOpened, setQrInputOpened } =
     useUiStore(getUiStore);
 
-  const close = useCallback(() => setScannerOpened(false), [setScannerOpened]);
+  const close = useCallback(() => {
+    setScannerOpened(false);
+    const stream = videoRef.current?.srcObject as MediaStream | null;
+    stream?.getTracks().forEach((track) => track.stop());
+  }, [setScannerOpened]);
 
   const onClickManualInput = useCallback(
     () => setQrInputOpened(true),


### PR DESCRIPTION
releases video stream when QR scanner closes. allows camera to shut down when not using scanner

tested and working on desktop, ios safari, and android google chrome