### PR TITLE
fix: block double proof submission

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -52,6 +52,7 @@ export function Modal() {
 
   const close = useCallback(() => {
     setOpen(false);
+    setShowConfirm(false);
     reset();
   }, [reset, setOpen]);
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -66,6 +66,8 @@ export function Modal() {
     ) => {
       if (!activeIdentity) return;
 
+      setStatus(Status.Pending);
+
       await generateIdentityProofsIfNeeded(activeIdentity);
 
       if (!bridgeInitialData) {
@@ -99,7 +101,6 @@ export function Modal() {
 
       if (url) {
         setShowConfirm(false);
-        setStatus(Status.Pending);
 
         const approveResult = await approveRequest({
           url,


### PR DESCRIPTION
sets modal status to pending immediately when credential is selected rather than after generating proof

https://github.com/worldcoin/simulator/assets/29718876/76ee16b5-6d54-44f4-be50-cb7d6744a2e5

