### PR TITLE
Allow world.org URLs

### DIFF
--- a/src/components/QR/QRInput.tsx
+++ b/src/components/QR/QRInput.tsx
@@ -30,7 +30,7 @@ export const QRInput = memo(function QRInput(props: {
 
       return !(
         url.protocol == "https:" &&
-        url.host == "worldcoin.org" &&
+        (url.host == "worldcoin.org" || url.host == "world.org") &&
         url.pathname == "/verify" &&
         url.searchParams.get("t") == "wld" &&
         url.searchParams

--- a/src/hooks/useIdentity.ts
+++ b/src/hooks/useIdentity.ts
@@ -59,12 +59,11 @@ const useIdentity = () => {
         verified: {
           [VerificationLevel.Orb]: orbProof !== null,
           [VerificationLevel.Device]: deviceProof !== null,
-        },
-
+        } as Record<VerificationLevel, boolean>,
         inclusionProof: {
           [VerificationLevel.Orb]: orbProof,
           [VerificationLevel.Device]: deviceProof,
-        },
+        } as Record<VerificationLevel, InclusionProofResponse | null>,
         proofGenerationTime: Date.now(),
       };
 
@@ -99,11 +98,11 @@ const useIdentity = () => {
         verified: {
           [VerificationLevel.Orb]: true,
           [VerificationLevel.Device]: true,
-        },
+        } as Record<VerificationLevel, boolean>,
         inclusionProof: {
           [VerificationLevel.Orb]: null,
           [VerificationLevel.Device]: null,
-        },
+        } as Record<VerificationLevel, InclusionProofResponse | null>,
         proofGenerationTime: null,
       };
       insertIdentity(identity);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -70,7 +70,7 @@ export async function retryDownload(): Promise<void> {
 export const SEQUENCER_ENDPOINT: Record<VerificationLevel, string> = {
   [VerificationLevel.Orb]: ORB_SEQUENCER_STAGING,
   [VerificationLevel.Device]: PHONE_SEQUENCER_STAGING,
-};
+} as Record<VerificationLevel, string>;
 
 export const cn = (...inputs: ClassValue[]): string => twMerge(clsx(inputs));
 

--- a/src/services/sequencer.ts
+++ b/src/services/sequencer.ts
@@ -9,7 +9,7 @@ const SEQUENCER_STAGING_PASSWORD: Record<
   [VerificationLevel.Orb]: process.env.POLYGON_ORB_SEQUENCER_STAGING_PASSWORD,
   [VerificationLevel.Device]:
     process.env.POLYGON_PHONE_SEQUENCER_STAGING_PASSWORD,
-};
+} as Record<VerificationLevel, string | undefined>;
 
 function buildUrl(endpoint: string, verificationLevel: VerificationLevel) {
   return new URL(endpoint, SEQUENCER_ENDPOINT[verificationLevel]);


### PR DESCRIPTION
Update the validation to support world.org as the host. IDKit now uses world.org.