### PR TITLE
docs: add a minimal test application example to the MCP guide

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,3 +26,62 @@ automatically. In short: start verification in the application under test, pass
 its IDKit connector URI as `connect_url`, and judge success by the application's
 own backend response — proof delivery is not application acceptance. Never log
 connection URLs; they contain the bridge's encryption key.
+
+## Minimal test application
+
+`complete_test_request` completes a request that your application created, so
+the application must sign and publish a real IDKit request and verify the
+delivered proof itself. The smallest working shape with
+`@worldcoin/idkit-core@4.2.1`:
+
+Backend (Node):
+
+```js
+import { signRequest } from "@worldcoin/idkit-core/signing";
+
+// Sign a fresh staging request server-side. Never expose the signing key.
+const action = `mcp-test-${crypto.randomUUID()}`;
+const signature = signRequest({ signingKeyHex, action, ttl: 600 });
+const config = {
+  app_id,
+  action,
+  environment: "staging",
+  allow_legacy_proofs: false,
+  rp_context: {
+    rp_id,
+    nonce: signature.nonce,
+    created_at: signature.createdAt,
+    expires_at: signature.expiresAt,
+    signature: signature.sig,
+  },
+};
+
+// Later: verify whatever the page hands back, unmodified.
+const response = await fetch(
+  `https://developer.world.org/api/v4/verify/${rp_id}`,
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...completionResult, min_protocol_version: "4.0" }),
+  },
+);
+```
+
+Page (browser, IDKit global bundle):
+
+```js
+const request = await IDKit.request(config).preset(IDKit.proofOfHuman());
+// request.connectorURI is the connect_url for complete_test_request.
+// Never log it: it contains the bridge encryption key.
+const completion = await request.pollUntilCompletion({ timeout: 600000 });
+if (completion.success) await postToBackendVerify(completion.result);
+```
+
+Serve `idkit.global.js` and `idkit_wasm_bg.wasm` together from the installed
+package: the SDK loads its WASM relative to the script, and the package
+README's CDN snippet currently fails WASM initialization.
+
+Success means the application's backend received Portal HTTP 200 with
+`protocol_version` `"4.0"` and `environment` `"staging"` — not the tool's
+`proof_delivered` acknowledgment. Actions need no pre-registration; the verify
+endpoint creates them on first verification.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -31,8 +31,16 @@ connection URLs; they contain the bridge's encryption key.
 
 `complete_test_request` completes a request that your application created, so
 the application must sign and publish a real IDKit request and verify the
-delivered proof itself. The smallest working shape with
-`@worldcoin/idkit-core@4.2.1`:
+delivered proof itself.
+
+An official, deployed reference exists: the
+[IDKit example arena](https://idkit-js-example.vercel.app/)
+([source](https://github.com/worldcoin/idkit/tree/main/js/examples/nextjs),
+with a plain-browser variant beside it). Its `api/arena/rp-context` route also
+shows how to mint deliberately broken request contexts (invalid RP signature,
+expired timestamps, replayed nonces) for failure-path testing.
+
+The smallest working shape with `@worldcoin/idkit-core@4.2.1`:
 
 Backend (Node):
 
@@ -79,7 +87,9 @@ if (completion.success) await postToBackendVerify(completion.result);
 
 Serve `idkit.global.js` and `idkit_wasm_bg.wasm` together from the installed
 package: the SDK loads its WASM relative to the script, and the package
-README's CDN snippet currently fails WASM initialization.
+README's CDN snippet currently fails WASM initialization. `signRequest` is also
+exported from `@worldcoin/idkit-server`, which the official example uses for
+server-side signing.
 
 Success means the application's backend received Portal HTTP 200 with
 `protocol_version` `"4.0"` and `environment` `"staging"` — not the tool's


### PR DESCRIPTION
## What changes

Adds a **Minimal test application** section to `docs/mcp.md`: the smallest backend + page shape that signs a staging IDKit request with `@worldcoin/idkit-core@4.2.1`, exposes the connector URI for `complete_test_request`, and forwards the completion result to the Portal verify endpoint with `min_protocol_version: "4.0"`.

An end-to-end acceptance review of worldcoin/developer-portal#2325 found that a first-time agent could not assemble this integration from the existing instructions alone (finding F4), and that the idkit-core README's CDN snippet fails WASM initialization (finding F5) — so the example documents the tested local-asset path (`idkit.global.js` + `idkit_wasm_bg.wasm` served together from the installed package).

The example distills the validated fixture from #239's branch history; the same flow was completed live twice during the review (portal HTTP 200, native 4.0, staging).

## Validation

`pnpm spellcheck` passes (33 files, 0 issues). Docs-only change.