### PR TITLE
docs(mcp): document result shapes and the SSE envelope for raw clients

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -27,6 +27,13 @@ its IDKit connector URI as `connect_url`, and judge success by the application's
 own backend response — proof delivery is not application acceptance. Never log
 connection URLs; they contain the bridge's encryption key.
 
+Two transport details for hand-rolled clients: responses arrive as a
+server-sent-events envelope (`data: {…}` lines carrying the JSON-RPC message;
+MCP SDK clients handle this automatically), and a successful call returns
+`{ "status": "proof_delivered", "request_id": "…" }` — note `status`, not
+`outcome`. Failed calls set `isError` and carry `error`, `stage`, `outcome`,
+and `error_delivered` fields instead.
+
 ## Minimal test application
 
 `complete_test_request` completes a request that your application created, so

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -19,7 +19,7 @@ Workflow:
 4. Let the application's IDKit polling or callback receive the proof. proof_delivered means the proof reached IDKit — judge success by the application's backend response and business effects.
 5. If the application fails, fix it and start a fresh request.
 
-Failure results carry error, stage, outcome, and error_delivered. outcome "not_completed": no proof was delivered — check the reported stage and the application's IDKit result. outcome "unknown": proof generation or delivery may already have happened — inspect the original IDKit request before another attempt; never retry blindly. simulator_busy: this worker already has an active request; this call started nothing new.
+A successful call returns { "status": "proof_delivered", "request_id": "..." } — note status, not outcome. Failure results carry error, stage, outcome, and error_delivered. outcome "not_completed": no proof was delivered — check the reported stage and the application's IDKit result. outcome "unknown": proof generation or delivery may already have happened — inspect the original IDKit request before another attempt; never retry blindly. simulator_busy: this worker already has an active request; this call started nothing new.
 
 Never log or repeat connection URLs: they contain the bridge encryption key. The tool never needs the RP private signing key. Test invalid proofs and business-rule failures through the application's backend; this server does not synthesize them.`,
     },


### PR DESCRIPTION
## What changes

Two transport facts a second independent acceptance run of the agent flow tripped over (both Medium findings):

- Raw HTTP clients receive each JSON-RPC response as a server-sent-events `data:` envelope; the guide now says so (MCP SDK clients are unaffected).
- A successful `complete_test_request` returns `{ "status": "proof_delivered", "request_id": "…" }` — `status`, not `outcome` — while failures carry `error`/`stage`/`outcome`/`error_delivered`. The asymmetry made a minimal client misread success as an unknown state. Both `docs/mcp.md` and the server's `initialize` instructions now show the success shape.

That run otherwise completed the whole flow from published material in ~10 minutes: happy path, tamper rejection, nullifier-reuse replay, fresh repeat, and an app-side `invalid_rp_signature` case.

## Validation

20/20 tests, cspell clean. Docs and one instruction-string change only.